### PR TITLE
Change CircleCI artifacts download request to INFO

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Retrieval of key data from files (if they exist):
 
 
 ## Requirements
- - Service Catalogue API token
- - Github app ID / installation ID / private key
- - Circle CI token
- - Slackbot token (this uses the [`hmpps-sre-app`](https://api.slack.com/apps/A07BZTDHRNK/general) Slack app)
+The following secrets are required:
+ - **`GITHUB_APP_ID`** / **`GITHUB_APP_INSTALLATION_ID`** / **`GITHUB_APP_PRIVATE_KEY`** - Github keys
+ - **`CIRCLECI_API_ENDPOINT`** / **`CIRCLECI_TOKEN`** Circle CI token
+ - **`SLACK_BOT_TOKEN`** - this uses the [`hmpps-sre-app`](https://api.slack.com/apps/A07BZTDHRNK/general) Slack app
+ - **`SERVICE_CATALOGUE_API_ENDPOINT`** / **`SERVICE_CATALOGUE_API_KEY`** - Service Catalogue API token
+ - **`SC_FILTER`** (eg. `&filters[name][$contains]=-`) - Service Catalogue filter - **required for dev**
 
 


### PR DESCRIPTION
In debug mode this request logs the full REST URL, which includes the aws key and secret.
This sets the logging to INFO for this particular request only.

Also: some README tweaks that I forgot to commit yesterday.