### PR TITLE
Added backofflimit , ensures that the job will not retry if it fails.…

### DIFF
--- a/helm_deploy/hmpps-github-discovery/templates/discovery-cron-job.yaml
+++ b/helm_deploy/hmpps-github-discovery/templates/discovery-cron-job.yaml
@@ -1,12 +1,4 @@
 {{- if .Values.discoveryCronJob.enabled -}}
-# ---
-# apiVersion: v1
-# kind: ConfigMap
-# metadata:
-#   name: github-teams-discovery-script
-# data:
-#   github_teams_discovery.py: |-
-#     {{ .Files.Get "github_teams_discovery.py" | indent 4 }}
 
 ---
 apiVersion: batch/v1
@@ -21,6 +13,7 @@ spec:
   successfulJobsHistoryLimit: 5
   jobTemplate:
     spec:
+      backoffLimit: 0 # Set to 0 to prevent retries after job failure - API Rate limit is 15000 per hour so reties will not solve the issue
       ttlSecondsAfterFinished: 345600
       template:
         spec:


### PR DESCRIPTION
… The next attempt will only happen at the next scheduled time. API rate limit issue can't be solved with retries