### PR TITLE
Add a check for enforce_admins is not None before assigning it to data

### DIFF
--- a/processes/components.py
+++ b/processes/components.py
@@ -90,8 +90,8 @@ def get_repo_teams_info(repo, branch_protection, component_flags):
         branch_protection_restricted_teams
       )
 
-      enforce_admins = branch_protection.enforce_admins
-      data['github_enforce_admins_enabled'] = enforce_admins
+      if enforce_admins := branch_protection.enforce_admins:
+        data['github_enforce_admins_enabled'] = enforce_admins
 
     except Exception as e:
       log_error(f'Unable to get teams/admin information {repo.name}: {e}')


### PR DESCRIPTION
This avoids an exception which results in the app_disabled flag being set (which would be caused by the failure to read the data in the first place, not a `None` result, which is the case here