### PR TITLE
detect app type from GitHub topics

### DIFF
--- a/processes/components.py
+++ b/processes/components.py
@@ -237,9 +237,9 @@ def update_app_type(component, data):
     data['frontend'] = True
     data['api'] = False
 
-    # Check to see if the repo is an API (name ends in -api))
-    if re.search(r'(-api$)|(-API$)', f'{component_name}'):
-      log_debug("Detected '-api'  - setting api flag.")
+  # Check to see if the repo is an API (name ends in -api))
+  if re.search(r'(-api$)|(-API$)', f'{component_name}'):
+    log_debug("Detected '-api'  - setting api flag.")
     data['frontend'] = False
     data['api'] = True
 

--- a/processes/components.py
+++ b/processes/components.py
@@ -302,7 +302,7 @@ def process_independent_component(component, repo):
     log_warning(f'Unable to get topics for {repo.name}: {e}')
 
   # FRONTEND / API checks
-  update_frontend_api(component, data)
+  update_app_type(component, data)
 
   log_debug(
     f'Processed main branch independent components for {component_name}\ndata: {data}'

--- a/processes/components.py
+++ b/processes/components.py
@@ -221,7 +221,7 @@ def get_app_insights_cloud_role_name(
   return None
 
 
-def update_frontend_api(component, data):
+def update_app_type(component, data):
   component_name = component.get('name')
   # Check to see if the repo is a frontend one (based on the name)
   if re.search(


### PR DESCRIPTION
- **updating categorisation for frontend/api in components.py**
- **Update processes/components.py**
- **fix indentation so it does what I want it to do!**
- **Update processes/components.py**
- **Prioritise GitHub repo topics (api, frontend, library, worker) for determining component type. Falls back to name-based detection if no matching topics are found.**
