### PR TITLE
fix: support whitelist key and fix false positive in ip allow list detection

### DIFF
--- a/includes/helm.py
+++ b/includes/helm.py
@@ -54,15 +54,19 @@ def get_envs_from_helm(component, repo, services):
 
 
 def fetch_helm_default_values(
-  sc, helm_default_values, allow_list_key, component_name, data
+  sc, helm_default_values, allow_list_keys, component_name, data
 ):
   helm_defaults = {
     'mod_security': {},
     'alert_severity_label': None,
-    'ip_allow_list': (
-      fetch_yaml_values_for_key(helm_default_values, allow_list_key) or {}
-    ),
+    'ip_allow_list': {},
   }
+
+  # Support legacy and replacement key names for IP allow list settings.
+  for allow_list_key in allow_list_keys:
+    if ip_allow_list := fetch_yaml_values_for_key(helm_default_values, allow_list_key):
+      helm_defaults['ip_allow_list'] = ip_allow_list
+      break
 
   # Try to get the container image
   if container_image := helm_default_values.get('image', {}).get('repository', {}):
@@ -318,7 +322,7 @@ def get_info_from_helm(data, component, repo, services):
     return False
 
   # variables used for implementation of findind IP allowlist in helm values files
-  allow_list_key = 'allowlist'
+  allow_list_keys = ('allowlist', 'whitelist')
   ip_allow_list_data = {}
   ip_allow_list = {}
 
@@ -332,10 +336,12 @@ def get_info_from_helm(data, component, repo, services):
 
     # HEAT-223 Start : Read and collate data for IPallowlist from all environment
     # specific values.yaml files.
-    ip_allow_list[helm_file] = fetch_yaml_values_for_key(
-      gh.get_file_yaml(repo, f'{helm_dir}/{helm_file.name}'),
-      allow_list_key,
-    )
+    ip_allow_list[helm_file] = {}
+    helm_file_values = gh.get_file_yaml(repo, f'{helm_dir}/{helm_file.name}')
+    for allow_list_key in allow_list_keys:
+      if ip_allow_values := fetch_yaml_values_for_key(helm_file_values, allow_list_key):
+        ip_allow_list[helm_file] = ip_allow_values
+        break
     if ip_allow_list[helm_file]:
       ip_allow_list_data[helm_file.name] = ip_allow_list[helm_file]
     # HEAT-223 End : Read and collate data for IPallowlist from all environment
@@ -365,7 +371,7 @@ def get_info_from_helm(data, component, repo, services):
 
   if helm_default_values:
     helm_defaults = fetch_helm_default_values(
-      sc, helm_default_values, allow_list_key, component_name, data
+      sc, helm_default_values, allow_list_keys, component_name, data
     )
 
   # Main dictionary to store helm data as we go

--- a/includes/utils.py
+++ b/includes/utils.py
@@ -69,7 +69,9 @@ def is_ipallowList_enabled(yaml_data):
   ip_allow_list_enabled = False
   if isinstance(yaml_data, dict):
     for value in yaml_data.values():
-      if isinstance(value, dict) and value:
+      # Only string values (CIDR ranges) count as an active allowlist entry,
+      # matching how the helm template uses the data (kindIs "string" check).
+      if isinstance(value, dict) and value and any(isinstance(v, str) for v in value.values()):
         ip_allow_list_enabled = True
   return ip_allow_list_enabled
 

--- a/includes/utils.py
+++ b/includes/utils.py
@@ -71,8 +71,9 @@ def is_ipallowList_enabled(yaml_data):
     for value in yaml_data.values():
       # Only string values (CIDR ranges) count as an active allowlist entry,
       # matching how the helm template uses the data (kindIs "string" check).
-      if isinstance(value, dict) and value and any(isinstance(v, str) for v in value.values()):
-        ip_allow_list_enabled = True
+      if isinstance(value, dict) and value:
+        if any(isinstance(v, str) for v in value.values()):
+          ip_allow_list_enabled = True
   return ip_allow_list_enabled
 
 


### PR DESCRIPTION
- Read ip allowlist data from both `allowlist` and `whitelist` helm keys, with `allowlist` taking precedence, to support repos using either convention.
- Fix `is_ipallowList_enabled` incorrectly returning True when a team set `allowlist: false` now only counts an allowlist as enabled when at least one entry has a string value (name/CIDR range), matching the helm templates own `kindIs "string"` guard.
